### PR TITLE
Ignore 403 errors for headObject

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -377,7 +377,8 @@ Publisher.prototype.publish = function (headers, options) {
 
       // get s3 headers
       _this.client.headObject({ Key: file.s3.path }, function(err, res) {
-        if (err && err.statusCode !== 404) return cb(err);
+        //ignore 403 and 404 errors since we're checking if a file exists on s3
+        if (err && [403, 404].indexOf(err.statusCode) < 0) return cb(err);
 
         res = res || {};
 


### PR DESCRIPTION
headObject returns a 403 error (possibly because the user has ListBucket permission, while the s3 bucket itself does not.)  Confirmed it's one of the possible errors we should expect according to the docs.

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectHEAD.html
